### PR TITLE
Ability to write to a context when usecase is called from outside an execution order

### DIFF
--- a/lib/usecasing/base.rb
+++ b/lib/usecasing/base.rb
@@ -25,14 +25,14 @@ module UseCase
           instance.tap do | me |
             me.before
             me.perform
-          end 
+          end
         end
       end
 
       private
 
       def tx(execution_order, context)
-        ctx = Context.new(context)
+        ctx = (context.is_a?(Context) ? context : Context.new(context))
         executed = []
         execution_order.each do |usecase|
           break if !ctx.success? || ctx.stopped?
@@ -67,12 +67,12 @@ module UseCase
     def rollback; end
 
     def stop!
-      context.stop! 
+      context.stop!
     end
 
     def failure(key, value)
       @context.failure(key, value)
     end
-    
+
   end
 end

--- a/spec/execution_order_spec.rb
+++ b/spec/execution_order_spec.rb
@@ -1,18 +1,18 @@
 require 'spec_helper'
 
-describe UseCase::ExecutionOrder do 
+describe UseCase::ExecutionOrder do
 
-  context "with only one node" do 
-    it 'returns post order' do 
+  context "with only one node" do
+    it 'returns post order' do
       EOFirst = Class.new(UseCase::Base)
       expect(UseCase::ExecutionOrder.run(EOFirst)).to eql([EOFirst])
     end
   end
 
-  context "with two nodes" do 
-    it 'returns the dependency first' do 
+  context "with two nodes" do
+    it 'returns the dependency first' do
       EODepdency = Class.new(UseCase::Base)
-      EODependent = Class.new(UseCase::Base) do 
+      EODependent = Class.new(UseCase::Base) do
         depends EODepdency
       end
 
@@ -21,19 +21,39 @@ describe UseCase::ExecutionOrder do
     end
   end
 
-  context 'with repeated nodes' do 
+  context 'with repeated nodes' do
     it 'returns duplicated nodes'  do
       EORepeatedSMS = Class.new(UseCase::Base)
-      
-      EOAlert = Class.new(UseCase::Base) do 
+
+      EOAlert = Class.new(UseCase::Base) do
         depends EORepeatedSMS
       end
 
-      EOCreate = Class.new(UseCase::Base) do 
+      EOCreate = Class.new(UseCase::Base) do
         depends EOAlert, EORepeatedSMS
       end
 
       expect(UseCase::ExecutionOrder.run(EOCreate)).to eql([EORepeatedSMS, EOAlert, EORepeatedSMS, EOCreate])
+    end
+  end
+
+  context 'context sharing' do
+    it 'reads inner context values' do
+      FirstUseCase = Class.new(UseCase::Base) do
+        def perform
+          SecondUseCase.perform(context)
+        end
+      end
+
+      SecondUseCase = Class.new(UseCase::Base) do
+        def perform
+          context.second = 'The quick brown fox jumps over the lazy dog'
+        end
+      end
+
+      expect(FirstUseCase.perform.second).to eq (
+        'The quick brown fox jumps over the lazy dog')
+
     end
   end
 end


### PR DESCRIPTION

The idea behind this PR is: We have a condition and a given usecase calls either UseCase A or another usecase B. This means we can't put A nor B in the execution order. When this happens, we need to call them directly inside the first usecase. The "problem" with this, is that the caller would have to manually set context values written by any of those two conditional usecases. This way the caller would pass the context to the callee and any following dependent usecases would access the same values set in the conditional usecases. 

Example with the code below:

```ruby
class E < UseCase::Base
   depends A, D

   def perform
       puts context.result
       #outputs 'B result' or 'C result'
   end
end

class A < UseCase::Base
   def perform
      if foo 
         B.perform(context)
      else
         C.perform(context)
      end
   end 
end

class B < UseCase::Base
   def perform
      context.result = "B result"
   end
end

class C < UseCase::Base
   def perform
      context.result = "C result"
   end
end


class D < UseCase::Base

end

```



